### PR TITLE
Update docker-compose.yaml -> 3.0.39

### DIFF
--- a/elasticsearch/docker-compose.yaml
+++ b/elasticsearch/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   es01:
-    image: elasticsearch:7.16.2
+    image: elasticsearch:7.17.9
     container_name: es-01
     environment:
       - cluster.name=es-cluster

--- a/services/.env
+++ b/services/.env
@@ -11,4 +11,6 @@ GS_ES_PASSWORD=
 
 # Do not change these parameters until you're asker for:
 DOCKER_LOGIN=registry.creatio.com
-DOCKER_TAG=3.0.30
+DOCKER_TAG=3.0.39
+
+TraceDebugInfo=false

--- a/services/docker-compose.yaml
+++ b/services/docker-compose.yaml
@@ -2,8 +2,7 @@ version: '3'
 networks:
   gs-network:
     driver: bridge
-    driver_opts:
-      com.docker.network.enable_ipv6: "true"
+
 volumes:
   rabbitmq:
     driver: local
@@ -58,7 +57,7 @@ services:
 
   web-api:
     container_name: gs-web-api
-    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-web-api:${DOCKER_TAG:-3.0.27}
+    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-web-api:${DOCKER_TAG:-3.0.39}
     environment:
       - RequestTimeOut=${GS_REQUEST_TIMEOUT:-600000}
       - elasticLogin=${GS_ES_LOGIN}
@@ -87,7 +86,7 @@ services:
 
   web-indexing-service:
     container_name: gs-web-indexing-service
-    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-web-indexing-service:${DOCKER_TAG:-3.0.27}
+    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-web-indexing-service:${DOCKER_TAG:-3.0.39}
     environment:
       - elasticLogin=${GS_ES_LOGIN}
       - elasticPassword=${GS_ES_PASSWORD}
@@ -111,7 +110,7 @@ services:
 
   search-service:
     container_name: gs-search-service
-    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-search-service:${DOCKER_TAG:-3.0.27}
+    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-search-service:${DOCKER_TAG:-3.0.39}
     environment:
       - ElasticSearch__Url=${GS_ES_URL}
       - ElasticSearch__Login=${GS_ES_LOGIN}
@@ -132,7 +131,7 @@ services:
 
   scheduler:
     container_name: gs-scheduler
-    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-scheduler:${DOCKER_TAG:-3.0.27}
+    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-scheduler:${DOCKER_TAG:-3.0.39}
     environment:
       - DbType=${GS_COMMON_DB_TYPE:-postgresql}
       - DbDialectProvider=${GS_COMMON_DB_DIALECT_PROVIDER:-ServiceStack.OrmLite.PostgreSqlDialect, ServiceStack.OrmLite.PostgreSQL, Culture=neutral, PublicKeyToken=null}
@@ -152,7 +151,7 @@ services:
 
   worker:
     container_name: gs-worker-01
-    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-worker:${DOCKER_TAG:-3.0.27}
+    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-worker:${DOCKER_TAG:-3.0.39}
     environment:
       - elasticLogin=${GS_ES_LOGIN}
       - elasticPassword=${GS_ES_PASSWORD}
@@ -165,6 +164,7 @@ services:
       - RabbitMQSettings__ReplyRabbitQueueName=${GS_RABBITMQ_QUEUE_NAME_OUTBOX:-gs-outbox}
       - RabbitMQSettings__IncrementDays=${GS_DB_INCREMENT_DAYS:-500}
       - Log4NetPath=${LOG4NET_CONFIG_FILE:-log4net.production.config}
+      - TraceDebugInfo=${TraceDebugInfo:-false}
     restart: unless-stopped
     networks:
       - gs-network
@@ -175,7 +175,7 @@ services:
 
   worker-queried-single-task:
     container_name: gs-worker-queried-single-task
-    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-worker-queried-single-task:${DOCKER_TAG:-3.0.27}
+    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-worker-queried-single-task:${DOCKER_TAG:-3.0.39}
     environment:
       - elasticLogin=${GS_ES_LOGIN}
       - elasticPassword=${GS_ES_PASSWORD}
@@ -199,7 +199,7 @@ services:
 
   worker-replay:
     container_name: gs-worker-replay
-    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-worker-replay:${DOCKER_TAG:-3.0.27}
+    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-worker-replay:${DOCKER_TAG:-3.0.39}
     environment:
       - DbDialectProvider=${GS_COMMON_DB_DIALECT_PROVIDER:-ServiceStack.OrmLite.PostgreSqlDialect, ServiceStack.OrmLite.PostgreSQL, Culture=neutral, PublicKeyToken=null}
       - connectionStrings__db=${GS_DB_CONNECTION_STRING:-User ID=postgres;Password=postgres;Server=gs-postgres;Port=5432;Database=postgres;Pooling=true;MinPoolSize=0;MaxPoolSize=200}
@@ -217,7 +217,7 @@ services:
 
   worker-single:
     container_name: gs-worker-single
-    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-worker-single:${DOCKER_TAG:-3.0.27}
+    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-worker-single:${DOCKER_TAG:-3.0.39}
     environment:
       - elasticLogin=${GS_ES_LOGIN}
       - elasticPassword=${GS_ES_PASSWORD}
@@ -228,6 +228,7 @@ services:
       - RabbitMQSettings__RabbitQueueName=${GS_RABBITMQ_QUEUE_NAME_SINGLE_INBOX:-gs-single-inbox}
       - RabbitMQSettings__ReplyRabbitQueueName=${GS_RABBITMQ_QUEUE_NAME_SINGLE_OUTBOX:-gs-single-outbox}
       - Log4NetPath=${LOG4NET_CONFIG_FILE:-log4net.production.config}
+      - TraceDebugInfo=${TraceDebugInfo:-false}
     restart: unless-stopped
     networks:
       - gs-network
@@ -238,7 +239,7 @@ services:
 
   worker-single-replay:
     container_name: gs-worker-single-replay
-    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-worker-single-replay:${DOCKER_TAG:-3.0.27}
+    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-worker-single-replay:${DOCKER_TAG:-3.0.39}
     environment:
       - DbDialectProvider=${GS_COMMON_DB_DIALECT_PROVIDER:-ServiceStack.OrmLite.PostgreSqlDialect, ServiceStack.OrmLite.PostgreSQL, Culture=neutral, PublicKeyToken=null}
       - connectionStrings__db=${GS_DB_CONNECTION_STRING:-User ID=postgres;Password=postgres;Server=gs-postgres;Port=5432;Database=postgres;Pooling=true;MinPoolSize=0;MaxPoolSize=200}
@@ -257,7 +258,7 @@ services:
 
   worker-single-task:
     container_name: gs-worker-single-task
-    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-worker-single-task:${DOCKER_TAG:-3.0.27}
+    image: ${DOCKER_LOGIN:-registry.creatio.com}/gs-worker-single-task:${DOCKER_TAG:-3.0.39}
     environment:
       - DbType=${GS_COMMON_DB_TYPE:-postgresql}
       - DbDialectProvider=${GS_COMMON_DB_DIALECT_PROVIDER:-ServiceStack.OrmLite.PostgreSqlDialect, ServiceStack.OrmLite.PostgreSQL, Culture=neutral, PublicKeyToken=null}


### PR DESCRIPTION
Update gs version -> 3.0.39, elastic -> 7.17.9
Removed option enable_ipv6, as containers are not visible for each other in Ubuntu 22
Feature: custom templates when creating new index